### PR TITLE
Implementing new function decodeInputByTx

### DIFF
--- a/decoder.js
+++ b/decoder.js
@@ -120,8 +120,7 @@ class TronTxDecoder {
             };
 
         } catch (err) {
-            //throw new Error(err)
-            console.log(err)
+            throw new Error(err)
         }
     }
 


### PR DESCRIPTION
Function decodeInputByTx it's the better way when you need to analyse more than 200 transaction IDs per second and not wish to get ratelimited on trongrid.io.

This function doesn't need to get the contract ABI on /wallet/getcontract endpoint.

So if you wish to get contract functions like Transfer, Transferfrom, decimals and balanceOf, just use the ABI I've defined on this file. That's enough for me for this moment.